### PR TITLE
Fix issue #73 and implement the normalization in linear clause

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -162,7 +162,7 @@ int main( int argc, const char* argv[] ) {
 
 
     // example of calling ompparser without test file or producing DOT file.
-    const char* input = "omp for lastprivate(conditional:fghj)";
+    const char* input = "omp taskloop simd linear(val(s,f,e):3) linear(val(s,f,e):3)";
         OpenMPDirective* openMPAST = parseOpenMP(input, NULL);
         output(openMPAST);
 

--- a/main.cpp
+++ b/main.cpp
@@ -162,7 +162,7 @@ int main( int argc, const char* argv[] ) {
 
 
     // example of calling ompparser without test file or producing DOT file.
-    const char* input = "omp taskloop simd linear(val(s,f,e):3) linear(val(s,f,e):3)";
+    const char* input = "omp target parallel for if(target:3456) if ( b)";
         OpenMPDirective* openMPAST = parseOpenMP(input, NULL);
         output(openMPAST);
 

--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -3722,26 +3722,24 @@ void OpenMPLinearClause::mergeLinear(OpenMPDirective *directive, OpenMPClause* c
     std::vector<OpenMPClause*>* current_clauses = directive->getClauses(OMPC_linear);
     OpenMPClause* new_clause = NULL;
 
-   current_clauses = directive->getClauses(OMPC_linear);
+    current_clauses = directive->getClauses(OMPC_linear);
 
-    for ( std::vector<OpenMPClause*>::iterator it = current_clauses->begin(); it != current_clauses->end()-1; it++) {
-
-        OpenMPClause* it2 = current_clauses->back();
+    for (std::vector<OpenMPClause*>::iterator it = current_clauses->begin(); it != current_clauses->end()-1; it++) {
           
-        if ( ((OpenMPLinearClause*)(*it))->getModifier() == ((OpenMPLinearClause*)(it2))->getModifier() && ((OpenMPLinearClause*)(*it))->getUserDefinedStep() == ((OpenMPLinearClause*)(it2))->getUserDefinedStep()) {
-            std::vector<const char *>* expressions1 = ((OpenMPLinearClause*)(*it))->getExpressions();
-            std::vector<const char *>* expressions2 = current_clause->getExpressions();
+        if (((OpenMPLinearClause*)(*it))->getModifier() == ((OpenMPLinearClause*)current_clause)->getModifier() && ((OpenMPLinearClause*)(*it))->getUserDefinedStep() == ((OpenMPLinearClause*)current_clause)->getUserDefinedStep()) {
+            std::vector<const char *>* expressions_previous_clause = ((OpenMPLinearClause*)(*it))->getExpressions();
+            std::vector<const char *>* expressions_current_clause = current_clause->getExpressions();
 
-            for ( std::vector<const char *>::iterator it3 = expressions2->begin(); it3 != expressions2->end(); it3++) {
+            for (std::vector<const char *>::iterator it_expr_current = expressions_current_clause->begin(); it_expr_current != expressions_current_clause->end(); it_expr_current++) {
                 bool not_normalize = false;
-                for ( std::vector<const char *>::iterator it4 = expressions1->begin(); it4 != expressions1->end(); it4++) {
-                    if ( strcmp(*it3, *it4) == 0){
+                for (std::vector<const char *>::iterator it_expr_previous = expressions_previous_clause->begin(); it_expr_previous != expressions_previous_clause->end(); it_expr_previous++) {
+                    if (strcmp(*it_expr_current, *it_expr_previous) == 0){
                         not_normalize = true;
                         break;
                     }
                 }
-                if ( !not_normalize) {
-                    expressions1->push_back(*it3);
+                if (!not_normalize) {
+                    expressions_previous_clause->push_back(*it_expr_current);
                 }
             }
             current_clauses->pop_back();

--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -3707,7 +3707,8 @@ OpenMPClause* OpenMPLinearClause::addLinearClause(OpenMPDirective *directive, Op
         current_clauses = new std::vector<OpenMPClause*>();
         current_clauses->push_back(new_clause);
         (*all_clauses)[OMPC_linear] = current_clauses;
-        } else { 
+        } 
+        else { 
           //std::cerr << "Cannot have two bind clause for the directive " << directive->getKind() << ", ignored\n";           
             new_clause = new OpenMPLinearClause(modifier);
            current_clauses->push_back(new_clause);

--- a/src/OpenMPIR.h
+++ b/src/OpenMPIR.h
@@ -383,7 +383,7 @@ public:
     
     static OpenMPClause* addLinearClause(OpenMPDirective*, OpenMPLinearClauseModifier);
 
-    void mergeLinear(OpenMPDirective *, OpenMPClause* );
+    void mergeLinear(OpenMPDirective*, OpenMPClause*);
 
     std::string toString();
     //std::string expressionToString(bool);

--- a/src/OpenMPIR.h
+++ b/src/OpenMPIR.h
@@ -369,7 +369,7 @@ class OpenMPLinearClause : public OpenMPClause {
 protected:
     OpenMPLinearClauseModifier modifier; // linear modifier
 
-    std::string user_defined_step;
+    std::string user_defined_step = "";
 
 public:
     OpenMPLinearClause(OpenMPLinearClauseModifier _modifier) :
@@ -382,6 +382,8 @@ public:
     std::string getUserDefinedStep() { return user_defined_step; };
     
     static OpenMPClause* addLinearClause(OpenMPDirective*, OpenMPLinearClauseModifier);
+
+    void mergeLinear(OpenMPDirective *, OpenMPClause* );
 
     std::string toString();
     //std::string expressionToString(bool);

--- a/src/OpenMPKinds.h
+++ b/src/OpenMPKinds.h
@@ -329,6 +329,7 @@ enum OpenMPAllocateClauseAllocator {
     OPENMP_ALLOCATE_ALLOCATOR_KIND(thread)// omp_thread_mem_alloc
     OPENMP_ALLOCATE_ALLOCATOR_KIND(user)// user-defined allocator
     OPENMP_ALLOCATE_ALLOCATOR_KIND(unknown)
+    OPENMP_ALLOCATE_ALLOCATOR_KIND(unspecified)
 #undef OPENMP_ALLOCATE_ALLOCATOR_KIND
 };
 
@@ -355,6 +356,7 @@ enum OpenMPReductionClauseModifier {
     OPENMP_REDUCTION_MODIFIER(task)
     OPENMP_REDUCTION_MODIFIER(default)
     OPENMP_REDUCTION_MODIFIER(unknown)
+    OPENMP_REDUCTION_MODIFIER(unspecified)
 #undef OPENMP_REDUCTION_MODIFIER
 };
 
@@ -383,7 +385,8 @@ enum OpenMPReductionClauseIdentifier {
 enum OpenMPLastprivateClauseModifier {
 #define OPENMP_LASTPRIVATE_MODIFIER(Name) OMPC_LASTPRIVATE_MODIFIER_##Name,
     OPENMP_LASTPRIVATE_MODIFIER(conditional)
-    OPENMP_LASTPRIVATE_MODIFIER(unknown)
+
+    OPENMP_LASTPRIVATE_MODIFIER(unspecified)
 #undef OPENMP_LASTPRIVATE_MODIFIER
 };
 
@@ -401,12 +404,12 @@ enum OpenMPLinearClauseStep {
 /// modifiers for 'linear' clause.
 enum OpenMPLinearClauseModifier {
 #define OPENMP_LINEAR_MODIFIER(Name) OMPC_LINEAR_MODIFIER_##Name,
-    OPENMP_LINEAR_MODIFIER(unknown)
 
     OPENMP_LINEAR_MODIFIER(val)
     OPENMP_LINEAR_MODIFIER(ref)
     OPENMP_LINEAR_MODIFIER(uval)
     OPENMP_LINEAR_MODIFIER(user)
+    OPENMP_LINEAR_MODIFIER(unspecified)
 
 
 #undef OPENMP_LINEAR_MODIFIER
@@ -435,7 +438,7 @@ enum OpenMPScheduleClauseKind {
     OPENMP_SCHEDULE_KIND(runtime)
     OPENMP_SCHEDULE_KIND(user)
 
-    OPENMP_SCHEDULE_KIND(unknown)
+    OPENMP_SCHEDULE_KIND(unspecified)
 #undef OPENMP_SCHEDULE_KIND
 };
 
@@ -497,6 +500,7 @@ enum OpenMPUsesAllocatorsClauseAllocator {
     OPENMP_USESALLOCATORS_ALLOCATOR_KIND(thread)// omp_thread_mem_alloc
     OPENMP_USESALLOCATORS_ALLOCATOR_KIND(user)// user-defined allocator
     OPENMP_USESALLOCATORS_ALLOCATOR_KIND(unknown)
+    OPENMP_USESALLOCATORS_ALLOCATOR_KIND(unspecified)
 #undef OPENMP_USESALLOCATORS_ALLOCATOR_KIND
 };
 
@@ -505,7 +509,8 @@ enum OpenMPDeviceClauseModifier {
 #define OPENMP_DEVICE_MODIFIER(Name) OMPC_DEVICE_MODIFIER_##Name,
     OPENMP_DEVICE_MODIFIER(ancestor)
     OPENMP_DEVICE_MODIFIER(device_num)
-    OPENMP_DEVICE_MODIFIER(unknown)
+
+    OPENMP_DEVICE_MODIFIER(unspecified)
 #undef OPENMP_DEVICE_MODIFIER
 };
 
@@ -531,8 +536,9 @@ enum OpenMPInReductionClauseIdentifier {
 
 enum OpenMPDependClauseModifier {
 #define OPENMP_DEPEND_MODIFIER(Name) OMPC_DEPEND_MODIFIER_##Name,
-    OPENMP_DEPEND_MODIFIER(unknown)
     OPENMP_DEPEND_MODIFIER(iterator)
+    OPENMP_DEPEND_MODIFIER(unknown)
+    OPENMP_DEPEND_MODIFIER(unspecified)
 #undef OPENMP_DEPEND_MODIFIER
 };
 
@@ -552,21 +558,21 @@ enum OpenMPDependClauseType {
 enum OpenMPAffinityClauseModifier {
 #define OPENMP_AFFINITY_MODIFIER(Name) OMPC_AFFINITY_MODIFIER_##Name,
     OPENMP_AFFINITY_MODIFIER(iterator)
-    OPENMP_AFFINITY_MODIFIER(unknown)
+    OPENMP_AFFINITY_MODIFIER(unspecified)
 #undef OPENMP_AFFINITY_MODIFIER
 };
 
 enum OpenMPToClauseKind {
 #define OPENMP_TO_KIND(Name) OMPC_TO_##Name,
     OPENMP_TO_KIND(mapper)
-    OPENMP_TO_KIND(unknown)
+    OPENMP_TO_KIND(unspecified)
 #undef OPENMP_TO_KIND
 };
 
 enum OpenMPFromClauseKind {
 #define OPENMP_FROM_KIND(Name) OMPC_FROM_##Name,
     OPENMP_FROM_KIND(mapper)
-    OPENMP_FROM_KIND(unknown)
+    OPENMP_FROM_KIND(unspecified)
 #undef OPENMP_FROM_KIND
 };
 
@@ -581,6 +587,7 @@ enum OpenMPDefaultmapClauseBehavior {
     OPENMP_DEFAULTMAP_BEHAVIOR(none)
     OPENMP_DEFAULTMAP_BEHAVIOR(default)
     OPENMP_DEFAULTMAP_BEHAVIOR(unknown)
+    OPENMP_DEFAULTMAP_BEHAVIOR(unspecified)
 #undef OPENMP_DEFAULTMAP_BEHAVIOR
 };
 
@@ -605,10 +612,10 @@ enum OpenMPDeviceTypeClauseKind {
 /// modifiers for 'map' clause.
 enum OpenMPMapClauseModifier {
 #define OPENMP_MAP_MODIFIER(Name) OMPC_MAP_MODIFIER_##Name,
-    OPENMP_MAP_MODIFIER(unknown)
     OPENMP_MAP_MODIFIER(always)
     OPENMP_MAP_MODIFIER(close)
     OPENMP_MAP_MODIFIER(mapper)
+    OPENMP_MAP_MODIFIER(unspecified)
 #undef OPENMP_MAP_MODIFIER
 };
 enum OpenMPMapClauseType {
@@ -620,6 +627,7 @@ enum OpenMPMapClauseType {
     OPENMP_MAP_TYPE(release)
     OPENMP_MAP_TYPE(delete)
     OPENMP_MAP_TYPE(unknown)
+    OPENMP_MAP_TYPE(unspecified)
 #undef OPENMP_MAP_TYPE
 };
 enum OpenMPTaskReductionClauseIdentifier {

--- a/src/omplexer.ll
+++ b/src/omplexer.ll
@@ -391,7 +391,7 @@ threads                   { return THREADS; }
 
 <LINEAR_STATE>"("                           { return '('; }
 <LINEAR_STATE>")"                           { yy_pop_state(); return ')'; }
-<LINEAR_STATE>val/{blank}*"("               { return MODOFIER_VAL; }
+<LINEAR_STATE>val/{blank}*"("               { return MODOFIER_VAL; printf("yyui"); }
 <LINEAR_STATE>ref/{blank}*                  { return MODOFIER_REF; }
 <LINEAR_STATE>uval/{blank}*                 { return MODOFIER_UVAL; }
 <LINEAR_STATE>":"                           { return ':'; }

--- a/src/omplexer.ll
+++ b/src/omplexer.ll
@@ -391,7 +391,7 @@ threads                   { return THREADS; }
 
 <LINEAR_STATE>"("                           { return '('; }
 <LINEAR_STATE>")"                           { yy_pop_state(); return ')'; }
-<LINEAR_STATE>val/{blank}*"("               { return MODOFIER_VAL; printf("yyui"); }
+<LINEAR_STATE>val/{blank}*"("               { return MODOFIER_VAL; }
 <LINEAR_STATE>ref/{blank}*                  { return MODOFIER_REF; }
 <LINEAR_STATE>uval/{blank}*                 { return MODOFIER_UVAL; }
 <LINEAR_STATE>":"                           { return ':'; }

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -906,18 +906,18 @@ in_reduction_identifier : in_reduction_enum_identifier
                         ;
 
 in_reduction_enum_identifier :  '+'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_plus); }
-| '-'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_minus); }
-| '*'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_mul); }
-| '&'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitand); }
-| '|'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitor); }
-| '^'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitxor); }
-| LOGAND{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_logand); }
-| LOGOR{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_logor); }
-| MAX{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_max); }
-| MIN{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_min); }
-;
+                             | '-'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_minus); }
+                             | '*'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_mul); }
+                             | '&'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitand); }
+                             | '|'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitor); }
+                             | '^'{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_bitxor); }
+                             | LOGAND{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_logand); }
+                             | LOGOR{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_logor); }
+                             | MAX{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_max); }
+                             | MIN{ current_clause = current_directive->addOpenMPClause(OMPC_in_reduction,OMPC_IN_REDUCTION_IDENTIFIER_min); }
+                             ;
 
-depend_with_modifier_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unknown; } '(' depend_parameter ')' { depend_iterators_definition_class->clear();
+depend_with_modifier_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unspecified; } '(' depend_parameter ')' { depend_iterators_definition_class->clear();
 }
                              ;
 
@@ -947,7 +947,7 @@ depend_enum_type : IN { current_clause = current_directive->addOpenMPClause(OMPC
                  | DEPOBJ { current_clause = current_directive->addOpenMPClause(OMPC_depend, firstParameter, OMPC_DEPENDENCE_TYPE_depobj); }
                  ;
 
-depend_depobj_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unknown; }'(' dependence_depobj_parameter ')' {
+depend_depobj_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unspecified; }'(' dependence_depobj_parameter ')' {
 }
                      ;
 dependence_depobj_parameter : dependence_depobj_type ':' expression
@@ -957,7 +957,7 @@ dependence_depobj_type : IN             { current_clause = current_directive->ad
                        | INOUT          { current_clause = current_directive->addOpenMPClause(OMPC_depend, firstParameter, OMPC_DEPENDENCE_TYPE_inout, depend_iterators_definition_class); }
                        | MUTEXINOUTSET  { current_clause = current_directive->addOpenMPClause(OMPC_depend, firstParameter, OMPC_DEPENDENCE_TYPE_mutexinoutset); }
                        ;
-depend_ordered_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unknown; }'(' dependence_ordered_parameter ')' {
+depend_ordered_clause : DEPEND { firstParameter = OMPC_DEPEND_MODIFIER_unspecified; }'(' dependence_ordered_parameter ')' {
 }
                       ;
 dependence_ordered_parameter : dependence_ordered_type
@@ -973,8 +973,8 @@ priority_clause: PRIORITY {
 
 affinity_clause: AFFINITY '(' affinity_parameter ')' ;
 
-affinity_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_affinity); current_clause->addLangExpr($1);  }
-                   | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_affinity); current_clause->addLangExpr($1); } var_list
+affinity_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_affinity, OMPC_AFFINITY_MODIFIER_unspecified); current_clause->addLangExpr($1); }
+                   | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_affinity, OMPC_AFFINITY_MODIFIER_unspecified); current_clause->addLangExpr($1); } var_list
                    | affinity_modifier ':' var_list
                    ;
 
@@ -1038,7 +1038,7 @@ ext_implementation_defined_requirement: EXT_ EXPR_STRING {
                                       ;
 device_clause : DEVICE '(' device_parameter ')' ;
 
-device_parameter :   EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_device); current_clause->addLangExpr($1); }
+device_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_device, OMPC_DEVICE_MODIFIER_unspecified); current_clause->addLangExpr($1); }
                  | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_device); current_clause->addLangExpr($1); } var_list
                  | device_modifier_parameter ':' var_list
                  ;
@@ -1061,7 +1061,7 @@ is_device_ptr_clause : IS_DEVICE_PTR {
 } '(' var_list ')' {
 }
                      ;
-defaultmap_clause : DEFAULTMAP{ firstParameter = OMPC_DEFAULTMAP_BEHAVIOR_unknown; } '('  defaultmap_parameter ')'
+defaultmap_clause : DEFAULTMAP{ firstParameter = OMPC_DEFAULTMAP_BEHAVIOR_unspecified; } '('  defaultmap_parameter ')'
                   ;
 defaultmap_parameter : defaultmap_behavior
                      | defaultmap_behavior ':' defaultmap_category
@@ -1080,7 +1080,7 @@ defaultmap_category : CATEGORY_SCALAR { current_clause = current_directive->addO
                     | CATEGORY_AGGREGATE { current_clause = current_directive->addOpenMPClause(OMPC_defaultmap, firstParameter,OMPC_DEFAULTMAP_CATEGORY_aggregate); }
                     | CATEGORY_POINTER { current_clause = current_directive->addOpenMPClause(OMPC_defaultmap,firstParameter,OMPC_DEFAULTMAP_CATEGORY_pointer); }
                     ;
-uses_allocators_clause : USES_ALLOCATORS  { current_clause = current_directive->addOpenMPClause(OMPC_uses_allocators); firstParameter = OMPC_USESALLOCATORS_ALLOCATOR_unknown; firstStringParameter = ""; secondStringParameter = ""; } '(' uses_allocators_parameter ')' ;
+uses_allocators_clause : USES_ALLOCATORS  { current_clause = current_directive->addOpenMPClause(OMPC_uses_allocators); firstParameter = OMPC_USESALLOCATORS_ALLOCATOR_unspecified; firstStringParameter = ""; secondStringParameter = ""; } '(' uses_allocators_parameter ')' ;
 uses_allocators_parameter : allocators_list
                           | allocators_list ',' uses_allocators_parameter
                           ;
@@ -1100,11 +1100,11 @@ allocators_list_parameter_enum : DEFAULT_MEM_ALLOC { usesAllocator = OMPC_USESAL
                                | PTEAM_MEM_ALLOC { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_pteam;  }
                                | THREAD_MEM_ALLOC { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_thread; }
                                ;
-allocators_list_parameter_user : EXPR_STRING { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_unknown; secondStringParameter = $1; }
+allocators_list_parameter_user : EXPR_STRING { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_unspecified; secondStringParameter = $1; }
                                ;
 to_clause: TO '(' to_parameter ')' ;
-to_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_to); current_clause->addLangExpr($1);  }
-             | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_to); current_clause->addLangExpr($1); } var_list
+to_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_to, OMPC_TO_unspecified); current_clause->addLangExpr($1);  }
+             | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_to, OMPC_TO_unspecified); current_clause->addLangExpr($1); } var_list
              | to_mapper ':' var_list
              ;
 to_mapper : TO_MAPPER { current_clause = current_directive->addOpenMPClause(OMPC_to, OMPC_TO_mapper);
@@ -1112,8 +1112,8 @@ to_mapper : TO_MAPPER { current_clause = current_directive->addOpenMPClause(OMPC
           ;
 
 from_clause: FROM '(' from_parameter ')' ;
-from_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_from); current_clause->addLangExpr($1);  }
-               | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_from); current_clause->addLangExpr($1); } var_list
+from_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_from, OMPC_FROM_unspecified); current_clause->addLangExpr($1);  }
+               | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_from, OMPC_FROM_unspecified); current_clause->addLangExpr($1); } var_list
                | from_mapper ':' var_list
                ;
 from_mapper : FROM_MAPPER { current_clause = current_directive->addOpenMPClause(OMPC_from, OMPC_FROM_mapper); 
@@ -1131,10 +1131,10 @@ device_type_parameter : HOST { current_clause = current_directive->addOpenMPClau
                     | ANY { current_clause = current_directive->addOpenMPClause(OMPC_device_type, OMPC_DEVICE_TYPE_any); }
                     ;
 
-map_clause : MAP { firstParameter = OMPC_MAP_MODIFIER_unknown; secondParameter = OMPC_MAP_MODIFIER_unknown; thirdParameter = OMPC_MAP_MODIFIER_unknown; }'(' map_parameter')';
+map_clause : MAP { firstParameter = OMPC_MAP_MODIFIER_unspecified; secondParameter = OMPC_MAP_MODIFIER_unspecified; thirdParameter = OMPC_MAP_MODIFIER_unspecified; }'(' map_parameter')';
 
-map_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_map, firstParameter, secondParameter,thirdParameter, OMPC_MAP_TYPE_unknown, firstStringParameter); current_clause->addLangExpr($1); }
-              | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_map, firstParameter, secondParameter,thirdParameter, OMPC_MAP_TYPE_unknown, firstStringParameter); current_clause->addLangExpr($1); } var_list
+map_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_map, firstParameter, secondParameter,thirdParameter, OMPC_MAP_TYPE_unspecified, firstStringParameter); current_clause->addLangExpr($1); }
+              | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_map, firstParameter, secondParameter,thirdParameter, OMPC_MAP_TYPE_unspecified, firstStringParameter); current_clause->addLangExpr($1); } var_list
               | map_modifier_type ':' var_list
               ;
 map_modifier_type : map_type
@@ -3206,8 +3206,8 @@ bind_parameter : TEAMS { current_clause = current_directive->addOpenMPClause(OMP
                ;
 allocate_clause : ALLOCATE '(' allocate_parameter ')' ;
 
-allocate_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_allocate, OMPC_ALLOCATE_ALLOCATOR_unknown); current_clause->addLangExpr($1);  }
-                   | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_allocate, OMPC_ALLOCATE_ALLOCATOR_unknown); current_clause->addLangExpr($1); } var_list
+allocate_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_allocate, OMPC_ALLOCATE_ALLOCATOR_unspecified); current_clause->addLangExpr($1);  }
+                   | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_allocate, OMPC_ALLOCATE_ALLOCATOR_unspecified); current_clause->addLangExpr($1); } var_list
                    | allocator_parameter ':' { ; } var_list
                    ;
 allocator_parameter : DEFAULT_MEM_ALLOC { current_clause = current_directive->addOpenMPClause(OMPC_allocate, OMPC_ALLOCATE_ALLOCATOR_default); }
@@ -3245,8 +3245,8 @@ fortran_copyprivate_clause : COPYPRIVATE {
                            ;
 lastprivate_clause : LASTPRIVATE '(' lastprivate_parameter ')' ;
 
-lastprivate_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_lastprivate); current_clause->addLangExpr($1); }
-                      | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_lastprivate); current_clause->addLangExpr($1); } var_list
+lastprivate_parameter : EXPR_STRING { current_clause = current_directive->addOpenMPClause(OMPC_lastprivate, OMPC_LASTPRIVATE_MODIFIER_unspecified); current_clause->addLangExpr($1); }
+                      | EXPR_STRING ',' { current_clause = current_directive->addOpenMPClause(OMPC_lastprivate, OMPC_LASTPRIVATE_MODIFIER_unspecified); current_clause->addLangExpr($1); } var_list
                       | lastprivate_modifier ':'{;} var_list
                       ;
 
@@ -3254,18 +3254,18 @@ lastprivate_modifier : MODIFIER_CONDITIONAL { current_clause = current_directive
                      ;
 
 linear_clause : LINEAR '(' linear_parameter ')'
-              | LINEAR '(' linear_parameter ':' EXPR_STRING { ((OpenMPLinearClause*)current_clause)->setUserDefinedStep($5); } ')' 
+              | LINEAR '(' linear_parameter ':' EXPR_STRING { ((OpenMPLinearClause*)current_clause)->setUserDefinedStep($5); ((OpenMPLinearClause*)current_clause)->mergeLinear(current_directive, current_clause); } ')' 
               ;
 
 linear_clause_fortran : LINEAR '(' linear_parameter_fortran ')'
                       | LINEAR '(' linear_parameter_fortran ':' EXPR_STRING { ((OpenMPLinearClause*)current_clause)->setUserDefinedStep($5); } ')' 
                       ;
-linear_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_linear); current_clause->addLangExpr($1); }
-                 | EXPR_STRING ',' {current_clause = current_directive->addOpenMPClause(OMPC_linear); current_clause->addLangExpr($1); } var_list
+linear_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_linear, OMPC_LINEAR_MODIFIER_unspecified); current_clause->addLangExpr($1); }
+                 | EXPR_STRING ',' {current_clause = current_directive->addOpenMPClause(OMPC_linear, OMPC_LINEAR_MODIFIER_unspecified); current_clause->addLangExpr($1); } var_list
                  | linear_modifier '(' var_list ')'
                  ;
-linear_parameter_fortran : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_linear); current_clause->addLangExpr($1); }
-                         | EXPR_STRING ',' {current_clause = current_directive->addOpenMPClause(OMPC_linear); current_clause->addLangExpr($1); } var_list
+linear_parameter_fortran : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_linear, OMPC_LINEAR_MODIFIER_unspecified); current_clause->addLangExpr($1); }
+                         | EXPR_STRING ',' {current_clause = current_directive->addOpenMPClause(OMPC_linear, OMPC_LINEAR_MODIFIER_unspecified); current_clause->addLangExpr($1); } var_list
                          | linear_modifier_fortran '(' var_list ')'
                          ;
 linear_modifier : MODOFIER_VAL { current_clause = current_directive->addOpenMPClause(OMPC_linear,OMPC_LINEAR_MODIFIER_val); }
@@ -3347,7 +3347,7 @@ dist_schedule_clause : DIST_SCHEDULE '(' dist_schedule_parameter ')' {}
 dist_schedule_parameter : STATIC { current_clause = current_directive->addOpenMPClause(OMPC_dist_schedule,OMPC_DISTSCHEDULE_KIND_static); }
                         | STATIC { current_clause = current_directive->addOpenMPClause(OMPC_dist_schedule,OMPC_DISTSCHEDULE_KIND_static); } ',' var_list
                         ;
-schedule_clause : SCHEDULE { firstParameter = OMPC_SCHEDULE_KIND_unknown;secondParameter = OMPC_SCHEDULE_KIND_unknown; }'(' schedule_parameter ')' {
+schedule_clause : SCHEDULE { firstParameter = OMPC_SCHEDULE_KIND_unspecified; secondParameter = OMPC_SCHEDULE_KIND_unspecified; }'(' schedule_parameter ')' {
                 }
                 ;
 
@@ -3383,7 +3383,7 @@ shared_clause : SHARED {
                 current_clause = current_directive->addOpenMPClause(OMPC_shared);
                     } '(' var_list ')'
               ;
-loop_reduction_clause : REDUCTION { firstParameter = OMPC_REDUCTION_MODIFIER_unknown; } '(' loop_reduction_parameter ':' var_list ')' {
+loop_reduction_clause : REDUCTION { firstParameter = OMPC_REDUCTION_MODIFIER_unspecified; } '(' loop_reduction_parameter ':' var_list ')' {
                       }
                       ;
 loop_reduction_parameter : reduction_identifier {}
@@ -3391,7 +3391,7 @@ loop_reduction_parameter : reduction_identifier {}
                          ;
 loop_reduction_modifier : MODIFIER_DEFAULT { firstParameter = OMPC_REDUCTION_MODIFIER_default; }
                         ;
-reduction_clause : REDUCTION { firstParameter = OMPC_REDUCTION_MODIFIER_unknown; } '(' reduction_parameter ':' var_list ')' {
+reduction_clause : REDUCTION { firstParameter = OMPC_REDUCTION_MODIFIER_unspecified; } '(' reduction_parameter ':' var_list ')' {
                  }
                  ;
 

--- a/tests/taskloop_simd.txt
+++ b/tests/taskloop_simd.txt
@@ -5,5 +5,14 @@
 //One is starting with "omp", which is the input.
 //The other one is starting with "PASS: ", which is the result for validation.
 
-#pragma omp taskloop simd collapse(a) order(dasfe)  safelen(sd) simdlen(4) nontemporal(non, temporal) lastprivate(conditional:i, last, private) linear(var(s,f,e):2) linear(s,f,e)  aligned(s,f,e) if(taskloop:3456) shared(x,y,z) private (x, n[1:5]) firstprivate (foo(x), y) lastprivate(rt,e,tre) reduction (default, + : a, foo(x)) in_reduction (abc : x, y, z) default(shared) grainsize(8) num_tasks(45) collapse(34) final(890) priority(4) untied mergeable nogroup allocate (user_defined_test : m, n[1:5])
-PASS: #pragma omp taskloop simd if (taskloop: 3456) default (shared) private (x, n[1:5]) firstprivate (foo(x), y) shared (x, y, z) reduction (default, + : a, foo(x)) allocate (user_defined_test: m, n[1:5]) lastprivate (conditional: i, last, private) lastprivate (rt, e, tre) collapse (a, 34) order (dasfe) linear (var(s,f,e):2) linear (s, f, e) safelen (sd) simdlen (4) aligned (s, f, e) nontemporal (non, temporal) final (890) untied mergeable in_reduction (abc : x, y, z) priority (4) grainsize (8) num_tasks (45) nogroup
+#pragma omp taskloop simd collapse(a) order(dasfe)  safelen(sd) simdlen(4) nontemporal(non, temporal) lastprivate(conditional:i, last, private) linear(val(s,f,e):2) linear(s,f,e)  aligned(s,f,e) if(taskloop:3456) shared(x,y,z) private (x, n[1:5]) firstprivate (foo(x), y) lastprivate(rt,e,tre) reduction (default, + : a, foo(x)) in_reduction (abc : x, y, z) default(shared) grainsize(8) num_tasks(45) collapse(34) final(890) priority(4) untied mergeable nogroup allocate (user_defined_test : m, n[1:5])
+PASS: #pragma omp taskloop simd if (taskloop: 3456) default (shared) private (x, n[1:5]) firstprivate (foo(x), y) shared (x, y, z) reduction (default, + : a, foo(x)) allocate (user_defined_test: m, n[1:5]) lastprivate (conditional: i, last, private) lastprivate (rt, e, tre) collapse (a, 34) order (dasfe) linear (val( s, f, e) :2) linear (s, f, e) safelen (sd) simdlen (4) aligned (s, f, e) nontemporal (non, temporal) final (890) untied mergeable in_reduction (abc : x, y, z) priority (4) grainsize (8) num_tasks (45) nogroup
+
+#pragma omp taskloop simd linear(var(s,f,e):2) linear(val(s,f,g):2)
+PASS: #pragma omp taskloop simd linear (var(s,f,e):2) linear (val( s, f, g) :2)
+
+#pragma omp taskloop simd linear(val(s,f,e):2) linear(val(u,d,j):3)  
+PASS: #pragma omp taskloop simd linear (val( s, f, e) :2) linear (val( u, d, j) :3)
+
+#pragma omp taskloop simd linear(val(s,f,e):2) linear(val(s,e,j):2)  
+PASS: #pragma omp taskloop simd linear (val( s, f, e, j) :2)


### PR DESCRIPTION
Fixed the bugs in linear and lastprivate clauses. Now under ubuntu 18.04, using gcc 7.4 and gcc 8.3 can work well.
For linear clause, the old version just compare the modifier.
The linear clause is shown as follow:
linear(linear-list[ : linear-step]), where linear-list is a list or "modifier(list)"
Now the latest version compares modifier and step. Only when they are both same, the two linear clauses can be merged.
For example:
linear(var(s,f,e):2) linear(val(s,f,y):2) should be merged as linear(val(s,f,e,y):2)
linear(var(s,f,e):2) linear(val(s,f,y):3)  should not be merged.