### PR TITLE
Fixed issue #97

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -163,7 +163,7 @@ int main( int argc, const char* argv[] ) {
 
     // example of calling ompparser without test file or producing DOT file.
     // setLang(Lang_C);
-    const char* input = "omp scan inclusive(a,b,c)";
+    const char* input = "omp requires ext_user_test reverse_offload unified_address unified_shared_memory,atomic_default_mem_order(acq_rel) dynamic_allocators";
         OpenMPDirective* openMPAST = parseOpenMP(input, NULL);
         output(openMPAST);
 

--- a/main.cpp
+++ b/main.cpp
@@ -163,7 +163,7 @@ int main( int argc, const char* argv[] ) {
 
     // example of calling ompparser without test file or producing DOT file.
     // setLang(Lang_C);
-    const char* input = "omp distribute dist_schedule(static,a)";
+    const char* input = "omp scan inclusive(a,b,c)";
         OpenMPDirective* openMPAST = parseOpenMP(input, NULL);
         output(openMPAST);
 

--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -157,6 +157,10 @@ OpenMPClause * OpenMPDirective::addOpenMPClause(int k, ... ) {
             new_clause = OpenMPOrderClause::addOrderClause(this, order_kind);
             break;
         }
+        case OMPC_ext_implementation_defined_requirement : {
+            new_clause = OpenMPExtImplementationDefinedRequirementClause::addExtImplementationDefinedRequirementClause(this);
+            break;
+        }
         case OMPC_match: {
             new_clause = OpenMPMatchClause::addMatchClause(this);
             break;
@@ -479,6 +483,41 @@ OpenMPClause* OpenMPLinearClause::addLinearClause(OpenMPDirective *directive, Op
     return new_clause;
 };
 
+OpenMPClause* OpenMPExtImplementationDefinedRequirementClause::addExtImplementationDefinedRequirementClause(OpenMPDirective *directive) {
+
+    std::map<OpenMPClauseKind, std::vector<OpenMPClause*>* >* all_clauses = directive->getAllClauses();
+    std::vector<OpenMPClause*>* current_clauses = directive->getClauses(OMPC_ext_implementation_defined_requirement);
+    OpenMPClause* new_clause = NULL;
+
+    if (current_clauses->size() == 0) {
+        new_clause = new OpenMPExtImplementationDefinedRequirementClause();
+        current_clauses = new std::vector<OpenMPClause*>();
+        current_clauses->push_back(new_clause);
+        (*all_clauses)[OMPC_ext_implementation_defined_requirement] = current_clauses;
+        } 
+        else {            
+            new_clause = new OpenMPExtImplementationDefinedRequirementClause();
+            current_clauses->push_back(new_clause);
+        };
+    (*all_clauses)[OMPC_ext_implementation_defined_requirement] = current_clauses;
+    return new_clause;
+};
+
+void OpenMPExtImplementationDefinedRequirementClause::mergeExtImplementationDefinedRequirement(OpenMPDirective *directive, OpenMPClause* current_clause) {
+
+    std::map<OpenMPClauseKind, std::vector<OpenMPClause*>* >* all_clauses = directive->getAllClauses();
+    std::vector<OpenMPClause*>* current_clauses = directive->getClauses(OMPC_ext_implementation_defined_requirement);
+    OpenMPClause* new_clause = NULL;
+
+    for (std::vector<OpenMPClause*>::iterator it = current_clauses->begin(); it != current_clauses->end()-1; it++) {
+        if (((OpenMPExtImplementationDefinedRequirementClause*)(*it))->getImplementationDefinedRequirement() == ((OpenMPExtImplementationDefinedRequirementClause*)current_clause)->getImplementationDefinedRequirement()) {
+            directive->getClausesInOriginalOrder()->pop_back();
+            std::cerr << "You can not have 2 same ext_implementation_defined_requirement clauses, ignored\n";
+            break;
+        }
+    }
+};
+
 void OpenMPLinearClause::mergeLinear(OpenMPDirective *directive, OpenMPClause* current_clause) {
 
     std::map<OpenMPClauseKind, std::vector<OpenMPClause*>* >* all_clauses = directive->getAllClauses();
@@ -505,6 +544,7 @@ void OpenMPLinearClause::mergeLinear(OpenMPDirective *directive, OpenMPClause* c
             }
             current_clauses->pop_back();
             directive->getClausesInOriginalOrder()->pop_back();
+
             break;
         }
     }

--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -494,11 +494,10 @@ OpenMPClause* OpenMPExtImplementationDefinedRequirementClause::addExtImplementat
         current_clauses = new std::vector<OpenMPClause*>();
         current_clauses->push_back(new_clause);
         (*all_clauses)[OMPC_ext_implementation_defined_requirement] = current_clauses;
-        } 
-        else {            
+    } else {            
             new_clause = new OpenMPExtImplementationDefinedRequirementClause();
             current_clauses->push_back(new_clause);
-        };
+    };
     (*all_clauses)[OMPC_ext_implementation_defined_requirement] = current_clauses;
     return new_clause;
 };

--- a/src/OpenMPIR.h
+++ b/src/OpenMPIR.h
@@ -191,11 +191,8 @@ public:
 
 class OpenMPRequiresDirective : public OpenMPDirective {
 protected:
-    std::vector<std::string> user_defined_implementation;
 public:
     OpenMPRequiresDirective () : OpenMPDirective(OMPD_requires) {};
-    void addUserDefinedImplementation (const char* _user_defined_implementation) { user_defined_implementation.push_back(std::string(_user_defined_implementation)); };
-    std::vector<std::string>* getUserDefinedImplementation() { return &user_defined_implementation; };
 };
 
 //declare variant directive
@@ -297,6 +294,24 @@ public:
 
     std::string toString();
     void generateDOT(std::ofstream&, int, int, std::string);
+};
+
+// ext_implementation_defined_requirement clause
+class OpenMPExtImplementationDefinedRequirementClause : public OpenMPClause {
+
+protected:
+    std::string implementation_defined_requirement; 
+
+public:
+    OpenMPExtImplementationDefinedRequirementClause() : OpenMPClause(OMPC_ext_implementation_defined_requirement) { }
+
+    void setImplementationDefinedRequirement(const char* _implementation_defined_requirement) { implementation_defined_requirement = _implementation_defined_requirement; };
+    std::string getImplementationDefinedRequirement() { return implementation_defined_requirement; };
+
+    static OpenMPClause * addExtImplementationDefinedRequirementClause(OpenMPDirective *);
+    void mergeExtImplementationDefinedRequirement(OpenMPDirective*, OpenMPClause*);
+    std::string toString();
+    //void generateDOT(std::ofstream&, int, int, std::string);
 };
 
 // initializer clause

--- a/src/OpenMPIRToString.cpp
+++ b/src/OpenMPIRToString.cpp
@@ -87,18 +87,6 @@ std::string OpenMPDirective::generatePragmaString(std::string prefix, std::strin
             result += ((OpenMPEndDirective*)this)->getPairedDirective()->generatePragmaString("", "", "");
             break;
         }
-        case OMPD_requires: {
-            std::vector<std::string> *ext_user_defined_implementation = ((OpenMPRequiresDirective*)this)->getUserDefinedImplementation();
-
-            if(ext_user_defined_implementation->size() > 0) {
-                std::vector<std::string>::iterator list_item;
-                for (list_item = ext_user_defined_implementation->begin(); list_item != ext_user_defined_implementation->end(); list_item++) {
-                    result += "ext_" + *list_item;
-                    result += " ";
-                };
-            };
-            break;
-        }
         case OMPD_declare_target: {
             std::vector<std::string>* list = ((OpenMPDeclareTargetDirective*)this)->getExtendedList();
             if(list->size() > 0){
@@ -198,6 +186,10 @@ std::string OpenMPDirective::toString() {
         case OMPD_parallel:
             result += "parallel ";
             break;
+        case OMPD_requires: {
+            result += "requires ";
+            break;
+        }
         case OMPD_teams:
             result += "teams " ;
             break;
@@ -320,9 +312,6 @@ std::string OpenMPDirective::toString() {
             break;
         case OMPD_taskyield:
             result += "taskyield ";
-            break;
-        case OMPD_requires:
-            result += "requires ";
             break;
         case OMPD_target_enter_data:
             result += "target enter data ";
@@ -664,6 +653,16 @@ std::string OpenMPClause::toString() {
 
     return result;
 
+};
+
+std::string OpenMPExtImplementationDefinedRequirementClause::toString() {
+    std::string result = "";
+    std::string parameter_string;
+
+    std::string ext_user_defined_implementation = this->getImplementationDefinedRequirement();
+    result += "ext_" + ext_user_defined_implementation;
+    result += " ";
+    return result;
 };
 
 std::string OpenMPAtomicDefaultMemOrderClause::toString() {

--- a/src/OpenMPKinds.h
+++ b/src/OpenMPKinds.h
@@ -178,6 +178,7 @@ enum OpenMPClauseKind {
     OPENMP_CLAUSE(unified_shared_memory, OMPUnifiedShared_memoryClause)
     OPENMP_CLAUSE(atomic_default_mem_order, OMPAtomicDefaultMemOrderClause)
     OPENMP_CLAUSE(dynamic_allocators, OMPDynamicAllocatorsClause)
+    OPENMP_CLAUSE(ext_implementation_defined_requirement, OMPExtImplementationDefinedRequirementClause)
 
     OPENMP_CLAUSE(device, OMPDeviceClause)
     OPENMP_CLAUSE(map, OMPMapClause)

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -839,7 +839,7 @@ requires_clause : reverse_offload_clause
                 | unified_shared_memory_clause   
                 | atomic_default_mem_order_clause 
                 | dynamic_allocators_clause
-                | ext_implementation_defined_requirement       
+                | ext_implementation_defined_requirement_clause       
                 ;
 target_data_clause : if_target_data_clause
                    | device_clause
@@ -1037,10 +1037,12 @@ dynamic_allocators_clause: DYNAMIC_ALLOCATORS {
                             current_clause = current_directive->addOpenMPClause(OMPC_dynamic_allocators);
                          } 
                          ;
-ext_implementation_defined_requirement: EXT_ EXPR_STRING {
-                                        ((OpenMPRequiresDirective*)current_directive)->addUserDefinedImplementation($2);
-                                      }
-                                      ;
+ext_implementation_defined_requirement_clause: EXT_ EXPR_STRING {
+                                               current_clause = current_directive->addOpenMPClause(OMPC_ext_implementation_defined_requirement);
+                                               ((OpenMPExtImplementationDefinedRequirementClause*)current_clause)->setImplementationDefinedRequirement($2);
+                                               ((OpenMPExtImplementationDefinedRequirementClause*)current_clause)->mergeExtImplementationDefinedRequirement(current_directive, current_clause);
+                                             }
+                                             ;
 device_clause : DEVICE '(' device_parameter ')' ;
 
 device_parameter : EXPR_STRING  { current_clause = current_directive->addOpenMPClause(OMPC_device, OMPC_DEVICE_MODIFIER_unspecified); current_clause->addLangExpr($1); }

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -2368,8 +2368,7 @@ parallel_master_taskloop_simd_clause_optseq : /*empty*/
 loop_clause_optseq : /*empty*/
                    | loop_clause_seq
                    ;
-scan_clause_optseq : /*empty*/
-                   | scan_clause_seq
+scan_clause_optseq : scan_clause_seq
                    ;
 sections_clause_optseq : /*empty*/
                        | sections_clause_seq


### PR DESCRIPTION
Create the new clause kind in OpenMPKinds.h, ext_Implementation-Defined-Requirement
Create a new class for the clause object:
Store the ext_ clause objects in the clauses map of the requires directive using the clause kind as the key.