### PR TITLE
Update CI testing matrix and fix minor bugs

### DIFF
--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-16.04]
-        gnu: [5, 6, 7, 8, 9]
+        os: [ubuntu-20.04, ubuntu-18.04]
+        gnu: [7, 8, 9, 10]
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-16.04]
-        llvm: ['6.0', 7, 8, 9, 10]
+        os: [ubuntu-20.04, ubuntu-18.04]
+        llvm: ['6.0', 7, 8, 9, 10, 11]
 
     runs-on: ${{ matrix.os }}
     env:
@@ -30,14 +30,14 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 
     - name: Add LLVM repository on Ubuntu 18.04
-      if: ${{ matrix.os }} == 'ubuntu-18.04' && ${{ matrix.os }} != '6.0'
+      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.llvm != '6.0' }}
       run: |
         sudo add-apt-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${{ matrix.llvm }} main'
 
-    - name: Add LLVM repository on Ubuntu 16.04
-      if: ${{ matrix.os }} == 'ubuntu-16.04' && ${{ matrix.os }} != '6.0'
+    - name: Add LLVM repository on Ubuntu 20.04
+      if: ${{ matrix.os == 'ubuntu-20.04' && matrix.llvm == 11 }}
       run: |
-        sudo add-apt-repository -y 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${{ matrix.llvm }} main'
+        sudo add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.llvm }} main'
 
     - name: Install dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #******************************************************************************************************************#
-# Copyright (c) 2018-2019, High Performance Computing Architecture and System
+# Copyright (c) 2018-2020, High Performance Computing Architecture and System
 # research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
 # and Lawrence Livermore National Security, LLC.
 #

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2019, High Performance Computing Architecture and System 
+Copyright (c) 2018-2020, High Performance Computing Architecture and System 
 research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
 and Lawrence Livermore National Security, LLC.
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 #include <stdio.h>
 #include <OpenMPIR.h>

--- a/ompparser.cpp
+++ b/ompparser.cpp
@@ -69,13 +69,11 @@ int main( int argc, const char* argv[] ) {
     };
     std::ifstream input_file;
 
-    if (filename != NULL) {
-        result = openFile(input_file, filename);
-    }
-    else {
+    if (filename == NULL) {
         std::cout << "No specific testing file is provided, use the default PARALLEL testing instead.\n";
-        result = openFile(input_file, "../tests/parallel.txt");
+        filename = "../tests/parallel.txt";
     };
+    result = openFile(input_file, filename);
     if (result) {
         std::cout << "No testing file is available.\n";
         return -1;

--- a/ompparser.cpp
+++ b/ompparser.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
 #include <fstream>
 #include <iostream>
 #include <regex>

--- a/preprocess_c.cpp
+++ b/preprocess_c.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
 #include <iostream>
 #include <regex>
 #include <fstream>

--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 #include "OpenMPIR.h"
 #include <stdarg.h>

--- a/src/OpenMPIR.h
+++ b/src/OpenMPIR.h
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 #ifndef OMPPARSER_OPENMPAST_H
 #define OMPPARSER_OPENMPAST_H

--- a/src/OpenMPIRToDOT.cpp
+++ b/src/OpenMPIRToDOT.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
 #include "OpenMPIR.h"
 #include <stdarg.h>
 

--- a/src/OpenMPIRToString.cpp
+++ b/src/OpenMPIRToString.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
 #include "OpenMPIR.h"
 #include <stdarg.h>
 

--- a/src/OpenMPKinds.h
+++ b/src/OpenMPKinds.h
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //===--- OpenMPKinds.h - OpenMP enums ---------------------------*- C++ -*-===//
 //

--- a/src/omplexer.ll
+++ b/src/omplexer.ll
@@ -1,10 +1,10 @@
-/******************************************************************************************************************
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//****************************************************************************************************************/
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 %option prefix="openmp_"
 /*%option outfile="lex.yy.c"*/

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 /* OpenMP C/C++/Fortran Grammar */
 

--- a/src/ompparser_config.h.cmake
+++ b/src/ompparser_config.h.cmake
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 #ifndef OMPPARSER_OMPPARSER_CONFIG_H
 #define OMPPARSER_OMPPARSER_CONFIG_H

--- a/test_folder.sh
+++ b/test_folder.sh
@@ -1,5 +1,5 @@
 #******************************************************************************************************************#
-# Copyright (c) 2018-2019, High Performance Computing Architecture and System
+# Copyright (c) 2018-2020, High Performance Computing Architecture and System
 # research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
 # and Lawrence Livermore National Security, LLC.
 #

--- a/tester.cpp
+++ b/tester.cpp
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 #include <stdio.h>
 #include <OpenMPIR.h>

--- a/tests/allocate.txt
+++ b/tests/allocate.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/allocate_fortran.txt
+++ b/tests/allocate_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/atomic.txt
+++ b/tests/atomic.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/atomic_fortran.txt
+++ b/tests/atomic_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/barrier.txt
+++ b/tests/barrier.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/barrier_fortran.txt
+++ b/tests/barrier_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/cancel.txt
+++ b/tests/cancel.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/cancel_fortran.txt
+++ b/tests/cancel_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/cancellation_point.txt
+++ b/tests/cancellation_point.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/cancellation_point_fortran.txt
+++ b/tests/cancellation_point_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/critical.txt
+++ b/tests/critical.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/critical_fortran.txt
+++ b/tests/critical_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_mapper.txt
+++ b/tests/declare_mapper.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_reduction.txt
+++ b/tests/declare_reduction.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_simd.txt
+++ b/tests/declare_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_simd_fortran.txt
+++ b/tests/declare_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_target.txt
+++ b/tests/declare_target.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/declare_target_fortran.txt
+++ b/tests/declare_target_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/depobj.txt
+++ b/tests/depobj.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/depobj_fortran.txt
+++ b/tests/depobj_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute.txt
+++ b/tests/distribute.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_fortran.txt
+++ b/tests/distribute_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_parallel_do_fortran.txt
+++ b/tests/distribute_parallel_do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_parallel_do_simd_fortran.txt
+++ b/tests/distribute_parallel_do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_parallel_for.txt
+++ b/tests/distribute_parallel_for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_parallel_for_simd.txt
+++ b/tests/distribute_parallel_for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_simd.txt
+++ b/tests/distribute_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/distribute_simd_fortran.txt
+++ b/tests/distribute_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/do_fortran.txt
+++ b/tests/do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/do_simd_fortran.txt
+++ b/tests/do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/end_declare_target.txt
+++ b/tests/end_declare_target.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/flush.txt
+++ b/tests/flush.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/flush_fortran.txt
+++ b/tests/flush_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/for.txt
+++ b/tests/for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/for_fortan.txt
+++ b/tests/for_fortan.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/for_simd.txt
+++ b/tests/for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/loop.txt
+++ b/tests/loop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/loop_fortran.txt
+++ b/tests/loop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/master_taskloop.txt
+++ b/tests/master_taskloop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/master_taskloop_fortran.txt
+++ b/tests/master_taskloop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/master_taskloop_simd.txt
+++ b/tests/master_taskloop_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/master_taskloop_simd_fortran.txt
+++ b/tests/master_taskloop_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/metadirective.txt
+++ b/tests/metadirective.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 
 //Only two kinds of special lines will be recognized.

--- a/tests/ordered.txt
+++ b/tests/ordered.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/ordered_fortran.txt
+++ b/tests/ordered_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel.txt
+++ b/tests/parallel.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_do_fortran.txt
+++ b/tests/parallel_do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_do_simd_fortran.txt
+++ b/tests/parallel_do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For simd testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_for.txt
+++ b/tests/parallel_for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_for_simd.txt
+++ b/tests/parallel_for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_loop.txt
+++ b/tests/parallel_loop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_loop_fortran.txt
+++ b/tests/parallel_loop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master.txt
+++ b/tests/parallel_master.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master_fortran.txt
+++ b/tests/parallel_master_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master_taskloop.txt
+++ b/tests/parallel_master_taskloop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master_taskloop_fortran.txt
+++ b/tests/parallel_master_taskloop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master_taskloop_simd.txt
+++ b/tests/parallel_master_taskloop_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_master_taskloop_simd_fortran.txt
+++ b/tests/parallel_master_taskloop_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_sections.txt
+++ b/tests/parallel_sections.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_sections_fortran.txt
+++ b/tests/parallel_sections_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_workshare.txt
+++ b/tests/parallel_workshare.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/parallel_workshare_fortran.txt
+++ b/tests/parallel_workshare_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/requires.txt
+++ b/tests/requires.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/requires_fortran.txt
+++ b/tests/requires_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/scan.txt
+++ b/tests/scan.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/scan_fortran.txt
+++ b/tests/scan_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/section.txt
+++ b/tests/section.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/section_fortran.txt
+++ b/tests/section_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/simd.txt
+++ b/tests/simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/simd_fortran.txt
+++ b/tests/simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/single.txt
+++ b/tests/single.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/single_fortran.txt
+++ b/tests/single_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target.txt
+++ b/tests/target.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_data.txt
+++ b/tests/target_data.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_data_fortran.txt
+++ b/tests/target_data_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_enter_data.txt
+++ b/tests/target_enter_data.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_enter_data_fortran.txt
+++ b/tests/target_enter_data_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_exit_data.txt
+++ b/tests/target_exit_data.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_exit_data_fortran.txt
+++ b/tests/target_exit_data_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_fortran.txt
+++ b/tests/target_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel.txt
+++ b/tests/target_parallel.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_do_fortran.txt
+++ b/tests/target_parallel_do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //FOR testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_do_simd_fortran.txt
+++ b/tests/target_parallel_do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_for.txt
+++ b/tests/target_parallel_for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_for_simd.txt
+++ b/tests/target_parallel_for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_fortran.txt
+++ b/tests/target_parallel_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_loop.txt
+++ b/tests/target_parallel_loop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_parallel_loop_fortran.txt
+++ b/tests/target_parallel_loop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_simd.txt
+++ b/tests/target_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_simd_fortran.txt
+++ b/tests/target_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams.txt
+++ b/tests/target_teams.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute.txt
+++ b/tests/target_teams_distribute.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_fortran.txt
+++ b/tests/target_teams_distribute_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_parallel_do_fortran.txt
+++ b/tests/target_teams_distribute_parallel_do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_parallel_do_simd_fortran.txt
+++ b/tests/target_teams_distribute_parallel_do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_parallel_for.txt
+++ b/tests/target_teams_distribute_parallel_for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_parallel_for_simd.txt
+++ b/tests/target_teams_distribute_parallel_for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_simd.txt
+++ b/tests/target_teams_distribute_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_distribute_simd_fortran.txt
+++ b/tests/target_teams_distribute_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_fortran.txt
+++ b/tests/target_teams_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_loop.txt
+++ b/tests/target_teams_loop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_teams_loop_fortran.txt
+++ b/tests/target_teams_loop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_update.txt
+++ b/tests/target_update.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/target_update_fortran.txt
+++ b/tests/target_update_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/task.txt
+++ b/tests/task.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/task_fortran.txt
+++ b/tests/task_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskgroup.txt
+++ b/tests/taskgroup.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskgroup_fortran.txt
+++ b/tests/taskgroup_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskloop.txt
+++ b/tests/taskloop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskloop_fortran.txt
+++ b/tests/taskloop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskloop_simd.txt
+++ b/tests/taskloop_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskloop_simd_fortran.txt
+++ b/tests/taskloop_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskwait.txt
+++ b/tests/taskwait.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskwait_fortran.txt
+++ b/tests/taskwait_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskyield.txt
+++ b/tests/taskyield.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/taskyield_fortran.txt
+++ b/tests/taskyield_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams.txt
+++ b/tests/teams.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute.txt
+++ b/tests/teams_distribute.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_fortran.txt
+++ b/tests/teams_distribute_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_parallel_do_fortran.txt
+++ b/tests/teams_distribute_parallel_do_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_parallel_do_simd_fortran.txt
+++ b/tests/teams_distribute_parallel_do_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_parallel_for.txt
+++ b/tests/teams_distribute_parallel_for.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_parallel_for_simd.txt
+++ b/tests/teams_distribute_parallel_for_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_simd.txt
+++ b/tests/teams_distribute_simd.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_distribute_simd_fortran.txt
+++ b/tests/teams_distribute_simd_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_fortran.txt
+++ b/tests/teams_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_loop.txt
+++ b/tests/teams_loop.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/teams_loop_fortran.txt
+++ b/tests/teams_loop_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/threadprivate.txt
+++ b/tests/threadprivate.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/threadprivate_fortran.txt
+++ b/tests/threadprivate_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.

--- a/tests/workshare_fortran.txt
+++ b/tests/workshare_fortran.txt
@@ -1,10 +1,10 @@
-//******************************************************************************************************************//
-// Copyright (c) 2018-2019, High Performance Computing Architecture and System
-// research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
-// and Lawrence Livermore National Security, LLC.
-//
-// SPDX-License-Identifier: (BSD-3-Clause)
-//*****************************************************************************************************************//
+/*
+ * Copyright (c) 2018-2020, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
 
 //For testing purpose, there are several extra empty lines.
 //The final version should only contain necessary information.


### PR DESCRIPTION
GCC 10, Clang 10 and 11 are not supported by default on Ubuntu 16.04. The tests on Ubuntu 16.04 are disabled temporarily.

Tests on Ubuntu 20.04 are added. 